### PR TITLE
PAUSE instead of exit in bat

### DIFF
--- a/run.bat
+++ b/run.bat
@@ -123,4 +123,4 @@ echo %start_scraper%
 set SCRIPT_PATH=main.py
 python %SCRIPT_PATH% %TYPE% %NAME% %LANGUAGUE% %DLMODE% %SEASON% %PROVIDER%
 echo %finish_scraper%
-exit
+PAUSE


### PR DESCRIPTION
Simply changed the run.bat from pausing instead of exiting. Since if it crashes, it closes immediatley, and you have no idea whats going on. And its also nice to see that it finished, instead of it closing, and you thinking it might crashed. You just have no idea what happened if it exits. 