### PR TITLE
[FEAT] Better Command Line Arguments Parsing

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -1,9 +1,18 @@
 import sys
+import re
 
 from src.custom_logging import setup_logger
 
 logger = setup_logger(__name__)
 
+def check_for_old_parse():
+    match sys.argv[1]:
+        case "serie" | "anime":
+            return True
+        case _:
+            return False
+
+use_old_parse = check_for_old_parse()
 
 def parse_cli_arguments(default: str | int, position: int) -> str | int:
     try:
@@ -16,6 +25,30 @@ def parse_cli_arguments(default: str | int, position: int) -> str | int:
         logger.debug(f"no cli argument detected on position:{position}. Using default value:{default}")
         return default
 
+args_pattern = re.compile(
+    r"^("
+    r"(--(?P<HELP>help).*)|"
+    r"((?:-t|--type)\s(?P<TYPE>serie|anime))|"
+    r"((?:-n|--name)\s(?P<NAME>[\w\-]*))|"
+    r"((?:-l|--lang)\s(?P<LANG>Deutsch|Ger-Sub|English))|"
+    r"((?:-m|--dl-mode)\s(?P<MODE>Series|Movies|All))|"
+    r"((?:-s|--season_override)\s(?P<SEASON>\d+))|"
+    r"((?:-p|--provider)\s(?P<PROVIDER>VOE|Streamtape|Vidoza))"
+    r")$"
+)
+
+def args_parse():
+    args_line = " ".join(sys.argv[1:])
+    args: Dict[str, str] = {}
+    if match_object := args_pattern.match(arg_line):
+        args = {k: v for k, v in match_object.groupdict().items()
+                if v is not None}
+    return args
+
+arguments = args_parse() if use_old_parse == False else {}
+
+def get_arg(name: str, default: str | int = None):
+    return arguments.get(name, default)
 
 # ------------------------------------------------------- #
 #                   definitions
@@ -25,12 +58,12 @@ APP_VERSION = "v01-10-00"
 # ------------------------------------------------------- #
 #                   global variables
 # ------------------------------------------------------- #
-type_of_media = parse_cli_arguments("anime", 1)  # choose 'serie' or 'anime'
-name = parse_cli_arguments("Name-Goes-Here", 2)
-language = parse_cli_arguments("Deutsch", 3)
-dlMode = parse_cli_arguments("Series", 4)  # Options: Movies, Series, All
-season_override = parse_cli_arguments(0, 5)  # 0 = no override. 1 = season 1. etc...
-cliProvider = parse_cli_arguments("VOE", 6)  # 0 = no override. 1 = season 1. etc...
+type_of_media = parse_cli_arguments("anime", 1) if use_old_parse else get_arg("TYPE", "anime") # choose 'serie' or 'anime'
+name = parse_cli_arguments("Name-Goes-Here", 2) if use_old_parse else get_arg("NAME", "Name-Goes-Here")
+language = parse_cli_arguments("Deutsch", 3) if use_old_parse else get_arg("LANG", "Deutsch")
+dlMode = parse_cli_arguments("Series", 4) if use_old_parse else get_arg("MODE", "Series")  # Options: Movies, Series, All
+season_override = parse_cli_arguments(0, 5) if use_old_parse else get_arg("SEASON", 0)  # 0 = no override. 1 = season 1. etc...
+cliProvider = parse_cli_arguments("VOE", 6) if use_old_parse else get_arg("PROVIDER", "VOE")  # 0 = no override. 1 = season 1. etc...
 episode_override = 0  # 0 = no override. 1 = episode 1. etc...
 ddos_protection_calc = 5
 ddos_wait_timer = 60  # in seconds

--- a/src/constants.py
+++ b/src/constants.py
@@ -6,11 +6,10 @@ from src.custom_logging import setup_logger
 logger = setup_logger(__name__)
 
 def check_for_old_parse():
-    match sys.argv[1]:
-        case "serie" | "anime":
-            return True
-        case _:
-            return False
+    if sys.argv[1] == "serie" or sys.argv[1] == "anime":
+        return True
+    else:
+        return False
 
 use_old_parse = check_for_old_parse()
 
@@ -26,23 +25,25 @@ def parse_cli_arguments(default: str | int, position: int) -> str | int:
         return default
 
 args_pattern = re.compile(
-    r"^("
+    r"("
     r"(--(?P<HELP>help).*)|"
     r"((?:-t|--type)\s(?P<TYPE>serie|anime))|"
-    r"((?:-n|--name)\s(?P<NAME>[\w\-]*))|"
+    r"((?:-n|--name)\s(?P<NAME>[\w\-]+))|"
     r"((?:-l|--lang)\s(?P<LANG>Deutsch|Ger-Sub|English))|"
     r"((?:-m|--dl-mode)\s(?P<MODE>Series|Movies|All))|"
     r"((?:-s|--season_override)\s(?P<SEASON>\d+))|"
     r"((?:-p|--provider)\s(?P<PROVIDER>VOE|Streamtape|Vidoza))"
-    r")$"
+    r")"
 )
 
 def args_parse():
-    args_line = " ".join(sys.argv[1:])
+    arg_line = " ".join(sys.argv[1:])
     args: Dict[str, str] = {}
-    if match_object := args_pattern.match(arg_line):
-        args = {k: v for k, v in match_object.groupdict().items()
-                if v is not None}
+    if match_objects := args_pattern.finditer(arg_line):
+        for match_object in match_objects:
+            for item in match_object.groupdict().items():
+                if item[1] != None:
+                    args[item[0]] = item[1]
     return args
 
 arguments = args_parse() if use_old_parse == False else {}


### PR DESCRIPTION
Command line arguments can now be supplied like many other tools do it with the option flags.

```sh
main.py -n <show-name> --dl-mode <download-mode> -t <media-type> --lang <language>
```

so its now this basically

```sh
main.py [options/arguments]
```

Note that the order of options/flags is irrelevant and sometimes can be optional.

All current args/options/flags:
```
-t | --type <serie/anime>                        Type of media. Required. Has to be one of these: serie, anime
-n | --name <name>                               Name of the show. Required.
-l | --lang <Deutsch/Ger-Sub-English>            In what language the show should be downloaded. Required.
-m | --dl-mode <Series/Movies/All>               The download mode that should be used. Required.
-p | --provider <VOE/Streamtape/Vidoza>          Which stream provider should be used. Optional. Default: VOE
```

**Also note worthy - The old way of supplying arguments still works and makes it therefore fully backwards compatible**

Tested this personally, so it should be working let me know otherwise.

Best Regards, Mysti